### PR TITLE
Fix screen-reader reading lines twice in TextBox

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/internal/Automation/TextRangeAdapter.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationFramework/MS/internal/Automation/TextRangeAdapter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Windows;
+using System.Windows.Documents;
+
+namespace MS.Internal.Automation
+{
+    internal class TextRangeAdapter
+    {
+        private TextPointer _start;
+        private TextPointer _end;
+
+        public TextRangeAdapter(TextPointer start, TextPointer end)
+        {
+            _start = start;
+            _end = end;
+        }
+
+        public void ExpandToEnclosingUnit(TextUnit unit, bool expandStart, bool expandEnd)
+        {
+            if (unit == TextUnit.Line)
+            {
+                if (expandStart)
+                {
+                    _start = _start.GetLineStartPosition(0);
+                }
+
+                if (expandEnd)
+                {
+                    TextPointer lineEnd = _end.GetLineStartPosition(1);
+                    if (lineEnd == null || _end.CompareTo(lineEnd) == 0)
+                    {
+                        _end = _end.GetLineStartPosition(0);
+                    }
+                    else
+                    {
+                        _end = lineEnd;
+                    }
+                }
+            }
+        }
+    }
+
+    internal enum TextUnit
+    {
+        Line
+    }
+}


### PR DESCRIPTION
Modify `ExpandToEnclosingUnit` method in `TextRangeAdapter.cs` to ensure `_end` is set to the start of the current line instead of the next line.

* Add a check to handle blank lines correctly by setting `_end` to the start of the current line if the line is blank.

